### PR TITLE
Refine hero typography and spacing; update font imports

### DIFF
--- a/source/_volantis/headBegin.ejs
+++ b/source/_volantis/headBegin.ejs
@@ -4,7 +4,7 @@
 <!-- <script defer src="/js/shici.js"></script> -->
 
 <link rel="stylesheet" href="https://fontsapi.zeoseven.com/84/main/result.css">
-<link href="https://fonts.gstatic.cn/css2?family=Noto+Serif+SC:wght@300;400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&family=Jost:wght@300;400&family=Noto+Serif+SC:wght@200;300;400&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast/dist/css/iziToast.min.css">
 <link rel="stylesheet" href="/css/izitotal.css">

--- a/source/css/hero.css
+++ b/source/css/hero.css
@@ -47,8 +47,8 @@
 /* 中文标题行 */
 .title-line {
   display: block;
-  font-family: 'Noto Serif SC', 'Songti SC', serif;
-  font-weight: 300;
+  font-family: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC', 'STSong', 'SimSun', serif;
+  font-weight: 200;
   color: rgba(255,255,255,0.85);
   -webkit-font-smoothing: antialiased;
   line-height: 1.18;
@@ -65,7 +65,7 @@
 
 /* 第二行：右移，flex 让落款自然跟随 */
 .title-line-2 {
-  padding-left: 72px;
+  padding-left: 104px;
   margin-top: 8px;
   animation: slideInRight 1.2s 0.15s cubic-bezier(0.22,1,0.36,1) both;
   display: inline-flex;
@@ -102,7 +102,7 @@
 .colophon-text {
   font-family: 'Noto Serif SC', serif;
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 200;
   letter-spacing: 0.30em;
   color: rgba(240,237,228,0.72);
   writing-mode: vertical-rl;
@@ -126,7 +126,7 @@
   display: block;
   font-family: 'Jost', 'Inter', 'Helvetica Neue', Arial, sans-serif;
   font-size: 7px;
-  font-weight: 300;
+  font-weight: 200;
   letter-spacing: 0.26em;
   text-transform: uppercase;
   color: rgba(200,196,184,1);
@@ -158,7 +158,7 @@
 @media (max-width: 640px) {
   .hero { padding-top: 48px; }
   .title-line { font-size: 24px; letter-spacing: 0.20em; }
-  .title-line-2 { padding-left: 40px; }
+  .title-line-2 { padding-left: 64px; }
   .colophon { margin-bottom: -38px; }
   .colophon-text { font-size: 10px; }
   .title-en { font-size: 6px; margin-top: 14px; }


### PR DESCRIPTION
### Motivation
- Improve the hero/title visual appearance by switching font sources, adding serif and sans-serif families, and lightening weights for a more delicate, typographic look.
- Adjust horizontal offsets to rebalance the two-line bilingual title composition on desktop and mobile.

### Description
- Replace the previous Noto Serif SC import in `_volantis/headBegin.ejs` with a Google Fonts bundle that includes `Cormorant Garamond`, `Jost`, and updated `Noto Serif SC` weights.
- Update `.title-line` font stack to include `Source Han Serif SC`, `STSong`, and `SimSun`, and lower its `font-weight` to `200` for a lighter appearance.
- Increase `.title-line-2` left padding from `72px` to `104px` on desktop and from `40px` to `64px` for `@media (max-width: 640px)` to improve visual alignment.
- Lower `font-weight` for `.colophon-text` and `.title-en` from `400/300` to `200` to keep weight consistency across the hero block.

### Testing
- Ran the static site build with `npm run build`, which completed without errors.
- Executed the CSS linter with `npm run lint:css` (stylelint), and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72cb6863c832f9aa95b2b7bf35fee)